### PR TITLE
generic/556: reverse the order of comments to make the file look more…

### DIFF
--- a/tests/generic/556
+++ b/tests/generic/556
@@ -1,5 +1,5 @@
-# SPDX-License-Identifier: GPL-2.0+
 #!/bin/bash
+# SPDX-License-Identifier: GPL-2.0+
 # FS QA Test No. 556
 #
 # Test the basic functionality of filesystems with case-insensitive


### PR DESCRIPTION
Adjust the order of comments to show highlighting syntax when editing scripts.